### PR TITLE
ci: add phpstan level 2 analysis with GitHub Actions workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,48 @@
+name: PHPStan
+
+on:
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan level 2
+        run: composer phpstan
+
+  phpstan-lowest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install lowest dependencies
+        run: composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+
+      - name: Run PHPStan level 2
+        run: composer phpstan

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,48 @@
+name: Tests
+
+on:
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: composer test
+
+  tests-lowest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: composer:v2
+
+      - name: Install lowest dependencies
+        run: composer update --prefer-lowest --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,21 @@
       "Smichaelsen\\Caldera\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Smichaelsen\\Caldera\\Test\\": "tests/"
+    }
+  },
   "require": {
-    "php": "^7.0 || ^8.0"
+    "php": "^7.3 || ^8.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.12.1",
-    "phpunit/phpunit": "^6"
+    "phpunit/phpunit": "^9 || ^10 || ^11",
+    "phpstan/phpstan": "^2.1"
+  },
+  "scripts": {
+    "phpstan": "phpstan analyse",
+    "test": "phpunit"
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+  level: 2
+  paths:
+    - src

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/InputEvaluatorTest.php
+++ b/tests/InputEvaluatorTest.php
@@ -59,7 +59,7 @@ XML;
         $this->assertSame($expectedValue, InputEvaluator::getValueFromSimpleXMLElement($xmlObject, $valuePath));
     }
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['name', 'Bob Torrance'],

--- a/tests/Validation/IsAlphanumericValidatorTest.php
+++ b/tests/Validation/IsAlphanumericValidatorTest.php
@@ -19,7 +19,7 @@ class IsAlphanumericValidatorTest extends TestCase
         $this->assertEquals($expected, $validator->validate($value));
     }
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['', true],

--- a/tests/Validation/IsNotEmptyValidatorTest.php
+++ b/tests/Validation/IsNotEmptyValidatorTest.php
@@ -19,7 +19,7 @@ class IsNotEmptyValidatorTest extends TestCase
         $this->assertEquals($expected, $validator->validate($value));
     }
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['', false],

--- a/tests/Validation/IsNumericValidatorTest.php
+++ b/tests/Validation/IsNumericValidatorTest.php
@@ -19,7 +19,7 @@ class IsNumericValidatorTest extends TestCase
         $this->assertEquals($expected, $validator->validate($value));
     }
 
-    public function dataProvider()
+    public static function dataProvider()
     {
         return [
             ['', true],


### PR DESCRIPTION
Adds phpstan ^2.1 as a dev dependency with a phpstan.neon config (level 2, paths: src/) and a GitHub Actions workflow that runs on push and pull_request, testing both latest and lowest dependencies.

Also updates phpunit from ^6 (blocked by security advisory) to ^9 || ^10 || ^11 and raises the PHP floor from ^7.0 to ^7.3 accordingly.